### PR TITLE
Fix date format for historical quote fetching

### DIFF
--- a/beancount_moex/source.py
+++ b/beancount_moex/source.py
@@ -24,11 +24,11 @@ def _get_quote(ticker: str, date=None):
     if len(ticker_parts) == 4:
         engine, market, board, symbol = ticker_parts
         url_template = BOARD_DATE_URL if date is not None else BOARD_LATEST_URL
-        url = url_template.format(engine=engine, market=market, board=board, symbol=symbol, date=date)
+        url = url_template.format(engine=engine, market=market, board=board, symbol=symbol, date=date.date())
     elif len(ticker_parts) == 3:
         engine, market, symbol = ticker_parts
         url_template = DATE_URL if date is not None else LATEST_URL
-        url = url_template.format(engine=engine, market=market, symbol=symbol, date=date)
+        url = url_template.format(engine=engine, market=market, symbol=symbol, date=date.date())
     else:
         raise ValueError("Invalid ticker format")
 


### PR DESCRIPTION
Fixes error for commands like `bean-price -e CNY:beancount_moex/stock:bonds:TQOY:RU000A105M75 -d 2024-07-30`:
```
http.client.InvalidURL: URL can't contain control characters. '/iss/history/engines/stock/markets/bonds/boards/TQOY/securities/RU000A105M75.json?from=2024-07-30 13:00:00+00:00&till=2024-07-30 13:00:00+00:00' (found at least ' ')
```